### PR TITLE
added types for vue-electron

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+import Vue from 'vue'
+
+import { 
+  Clipboard, 
+  CrashReporter, 
+  DesktopCapturer, 
+  IpcRenderer, 
+  NativeImage, 
+  Remote, 
+  Shell, 
+  WebFrame } from 'electron'
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $electron: {
+      clipboard: Clipboard
+      crashReporter: CrashReporter
+      desktopCapturer: DesktopCapturer
+      ipcRenderer: IpcRenderer
+      nativeImage: NativeImage
+      remote: Remote
+      shell: Shell
+      webFrame: WebFrame
+    }
+  }
+}


### PR DESCRIPTION
Hi, so, as promised a few days ago, I did the types.d.ts. It is a tiny file

This should solve for those who download this package via npm and use the intelisense. I honestly don't know if it is correct way to type the package, but it works in my environment.

Can you take a look too, please ? 

:)